### PR TITLE
Removed class lineage from inheritance api

### DIFF
--- a/src/main/java/ar/com/kfgodel/diamond/api/types/inheritance/TypeInheritance.java
+++ b/src/main/java/ar/com/kfgodel/diamond/api/types/inheritance/TypeInheritance.java
@@ -51,14 +51,6 @@ public interface TypeInheritance {
     TypeLineage typeLineage();
 
     /**
-     * Returns this class lineage (starting from this type, the set of inherited classes up until Object).<br>
-     *     This lineage does have type parameters coherency, because follows raw class inheritance.<br>
-     *     In this lineage you will find run time related types
-     * @return The class lineage of this type
-     */
-    TypeLineage classLineage();
-
-    /**
      * Returns the set of supertypes composed by the super class and any directly implemented interface.<br>
      *     This method allows navigating the supertype tree of a type.<br>
      * @return A nary composed of the superclass and the interfaces

--- a/src/main/java/ar/com/kfgodel/diamond/impl/types/inheritance/SuppliedTypesInheritance.java
+++ b/src/main/java/ar/com/kfgodel/diamond/impl/types/inheritance/SuppliedTypesInheritance.java
@@ -48,18 +48,13 @@ public class SuppliedTypesInheritance implements TypeInheritance {
     }
 
     @Override
-    public TypeLineage classLineage() {
-        return FunctionBasedTypeLineage.create(type, (type) -> type.inheritance().superclass());
-    }
-
-    @Override
     public Nary<TypeInstance> supertypes() {
         return extendedType().joinedWith(implementedTypes());
     }
 
     @Override
     public boolean isSubTypeOf(TypeInstance objectType) {
-        return classLineage().allRelatedTypes().anyMatch(objectType::equals);
+        return typeLineage().allRelatedTypes().anyMatch(objectType::equals);
     }
 
     @Override

--- a/src/test/java/ar/com/kfgodel/diamond/unit/lineage/TypeLineageTest.java
+++ b/src/test/java/ar/com/kfgodel/diamond/unit/lineage/TypeLineageTest.java
@@ -126,7 +126,7 @@ public class TypeLineageTest extends JavaSpec<DiamondTestContext> {
                     TypeInheritance inheritance = Diamond.types().from(new ReferenceOf<List<String>>() {
                     }.getReferencedAnnotatedType()).inheritance();
 
-                    List<String> allTypeNames = inheritance.classLineage().allRelatedTypes().map(TypeInstance::declaration).collect(Collectors.toList());
+                    List<String> allTypeNames = inheritance.typeLineage().allRelatedTypes().map(TypeInstance::declaration).collect(Collectors.toList());
                     assertThat(allTypeNames)
                             .isEqualTo(Arrays.asList("java.util.List<java.lang.String>", "java.util.List",
                                     "java.util.Collection<java.lang.String>", "java.util.Collection",
@@ -136,24 +136,6 @@ public class TypeLineageTest extends JavaSpec<DiamondTestContext> {
 
             });
 
-        });
-
-        describe("class lineage", () -> {
-
-            beforeEach(() -> {
-                context().lineage(() -> Diamond.of(ChildClass.class).inheritance().classLineage());
-            });
-
-            it("doesn't have type arguments for any member", () -> {
-                TypeInstance childType = context().lineage().lowestDescendant();
-                assertThat(childType.generics().arguments().count()).isEqualTo(0);
-
-                TypeInstance parentType = context().lineage().ancestorOf(childType).get();
-                assertThat(parentType.generics().arguments().count()).isEqualTo(0);
-
-                TypeInstance grandParentType = context().lineage().ancestorOf(parentType).get();
-                assertThat(grandParentType.generics().arguments().count()).isEqualTo(0);
-            });
         });
 
     }


### PR DESCRIPTION
The same can be probably achieved using only runtime types

https://github.com/kfgodel/diamond/issues/226